### PR TITLE
Fixing "Arguments to path.join must be strings", need to update bower dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ I'm going to add options to configure target dirs for asset types, like "css" go
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [grunt][].
 
 ## Release History
+* 2013/03/18 - v0.1.1 - Updated dependencies, minor fixes.
 * 2012/11/25 - v0.1.0 - Initial release.
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-bower-task",
   "description": "Install Bower packages.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/yatskevich/grunt-bower-task",
   "author": {
     "name": "Ivan Yatskevich",
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~0.6.0",
+    "bower": "~0.8.5",
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",
@@ -36,9 +36,9 @@
   },
   "devDependencies": {
     "grunt-contrib-jshint": "0.1.0",
-    "grunt-contrib-nodeunit": "~0.1.0",
-    "grunt": "~0.4.0",
-    "grunt-cli": "~0.1.1"
+    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.6"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
Currently this plugin causes `Arguments to path.join must be strings` with node 0.10.0

Relevant links:
http://stackoverflow.com/questions/15382662/grunt-fail-build-arguments-to-path-join-must-be-strings-error

Thanks!
