### PR TITLE
Split tasks into list, more flexible configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 *.iml
 /components/
 /lib/
+component.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
     bower: {
       install: {
         options: {
-          cleanTargetDir: false,
+          cleanTargetDir: true,
           cleanBowerDir: true,
           install: true,
           copy: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,14 +19,21 @@ module.exports = function(grunt) {
     },
 
     bower: {
-      cleanup: {
+      install: {
         options: {
-          cleanup: true,
-          install: false
+          cleanTargetDir: false,
+          cleanBowerDir: true,
+          install: true,
+          copy: true
         }
       },
-      install: {
-
+      cleanup: {
+        options: {
+          cleanTargetDir: true,
+          cleanBowerDir: true,
+          install: false,
+          copy: false
+        }
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -49,17 +49,29 @@ Default value: `./lib`
 
 A directory where you want to keep your Bower packages.
 
+### options.install
+Type: `Boolean`
+Default value: `true`
+
+Whether you want to run bower install task itself (e.g. you might not want to do this each time on CI server)
+
+### options.cleanTargetDir
+Type: `Boolean`
+Default value: `true`
+
+Will clean target dir before running install
+
+### options.cleanBowerDir
+Type: `Boolean`
+Default value: `true`
+
+Will remove bower's dir after copy all needed files into target dir
+
 #### options.cleanup
 Type: `boolean`
 Default value: `false`
 
-If you set `cleanup: true` then every time you run `grunt bower:install` both `components` and `./lib` (specified by `options.targetDir`) will be deleted.
-
-#### options.install
-Type: `boolean`
-Default value: `true`
-
-You can disable installation of Bower packages and just use this task to perform `cleanup`.
+If true - will set cleanBowerDir & cleanTargetDir to `true` (simple shortcut)
 
 #### options.layout
 Type: `string` or `function`
@@ -116,7 +128,7 @@ grunt.initConfig({
 Type: `boolean`
 Default value: `false`
 
-The task will provide more (debug) output when this option is set to `true`.
+The task will provide more (debug) output when this option is set to `true`. You can also use `--verbose` when running task for same affect.
 
 ### Usage Examples
 
@@ -127,13 +139,14 @@ Default options are good enough if you want to install Bower packages and keep o
 grunt.initConfig({
   bower: {
     install: {
-      // options: { 
-      //   targetDir: './lib',
-      //   cleanup: false,
-      //   install: true,
-      //   verbose: false,
-      //   layout: 'byType'
-      // }
+      options: { 
+        targetDir: './lib',
+        layout: 'byType',
+        install: true,
+        verbose: false,
+        cleanTargetDir: true,
+        cleanBowerDir: false
+      }
     }
   },
 })

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",
-    "colors": "~0.6.0-1"
+    "colors": "~0.6.0-1",
+    "async": "~0.2.5"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",
-    "colors": "~0.6.0-1",
-    "async": "~0.2.5"
+    "colors": "~0.6.0-1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "0.3.0",

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -10,74 +10,99 @@
 
 module.exports = function(grunt) {
 
-  var path = require('path');
-  var rimraf = require('rimraf').sync;
-  var bower = require('bower');
-  var colors = require('colors');
+  var bower = require('bower'),
+    path = require('path'),
+    async = require('async'),
+    colors = require('colors'),
+    rimraf = require('rimraf').sync,
+    BowerAssets = require('./lib/bower_assets'),
+    AssetCopier = require('./lib/asset_copier'),
+    LayoutsManager = require('./lib/layouts_manager');
 
-  var BowerAssets = require('./lib/bower_assets');
-  var AssetCopier = require('./lib/asset_copier');
-  var layoutsManager = require('./lib/layouts_manager');
+  function log(message) {
+    if (log.logger) {
+      log.logger.writeln(message);
+    }
+  }
+
+  function fail(error) {
+    grunt.fail.fatal(error);
+  }
+
+  function clean(dir, callback) {
+    log('grunt-bower ' + 'cleaning '.cyan + dir.grey);
+    rimraf(dir);
+    callback();
+  }
+
+  function install(callback) {
+    bower.commands.install()
+      .on('data', log)
+      .on('error', fail)
+      .on('end', callback);
+  }
+
+  function copy(options, callback) {
+    var bowerAssets = new BowerAssets(bower);
+    bowerAssets.once('data', function(assets) {
+      var copier = new AssetCopier(assets, options, function(source, destination, isFile) {
+        log('grunt-bower ' + 'copying '.cyan + ((isFile ? '' : ' dir ') + source + ' -> ' + destination).grey);
+      });
+
+      copier.once('copied', callback);
+      copier.copy();
+    }).get();
+  }
 
   grunt.registerMultiTask('bower', 'Install Bower packages.', function() {
-    var options = this.options({
-      targetDir: './lib',
-      cleanup: false,
-      install: true,
-      verbose: false,
-      layout: 'byType'
-    });
+    var tasks = [],
+      done = this.async(),
+      options = this.options({
+        cleanTargetDir: false,
+        cleanBowerDir: true,
+        targetDir: './lib',
+        layout: 'byType',
+        install: true,
+        verbose: true,
+        copy: true
+      }),
+      add = function(task) {
+        tasks.push(task);
+      },
+      bowerDir = path.resolve(bower.config.directory),
+      targetDir = path.resolve(options.targetDir);
 
-    try {
-      options.layout = layoutsManager.getLayout(options.layout);
-    } catch (error) {
-      grunt.fail.fatal(error);
-    }
+    log.logger = options.verbose && grunt.log;
+    options.layout = LayoutsManager.getLayout(options.layout, fail);
 
-    var targetDirPath = path.resolve(options.targetDir);
-
-    if (options.cleanup) {
-      cleanup(targetDirPath);
+    if (options.cleanTargetDir) {
+      add(function(callback) {
+        clean(targetDir, callback);
+      });
     }
 
     if (options.install) {
-      installBowerPackages(targetDirPath, options, this.async());
+      add(install);
     }
-  });
 
-  function cleanup(targetDirPath) {
-    rimraf(bower.config.directory);
-    grunt.log.writeln(('[notice]').yellow + ' cleaning up Bower packages');
-    rimraf(targetDirPath);
-    grunt.log.writeln(('[notice]').yellow + ' cleaning up ' + targetDirPath);
-  }
-
-  function installBowerPackages(targetDirPath, options, done) {
-    var verboseLog = options.verbose ? grunt.log : grunt.verbose;
-    bower.commands.install()
-      .on('data', function(data) {
-        verboseLog.writeln(data);
-      })
-      .on('end', function() {
-        var success = function() {
-          grunt.log.ok('Bower packages installed successfully into ' + targetDirPath);
-          done();
-        };
-
-        var copy = function(assets) {
-          var copier = new AssetCopier(assets, options, function(source, destination, isFile) {
-            verboseLog.writeln('Copied ' + (isFile ? '' : 'dir ') + source + ' -> ' + destination);
-          });
-
-          copier.once('copied', success).copy();
-        };
-
-        var bowerAssets = new BowerAssets(bower);
-        bowerAssets.once('data', copy).get();
-      })
-      .on('error', function(error) {
-        grunt.fail.fatal(error);
+    if (options.copy) {
+      add(function(callback) {
+        copy(options, callback);
       });
-  }
+    }
 
+    if (options.cleanBowerDir) {
+      add(function(callback) {
+        clean(bowerDir, callback);
+      });
+    }
+
+    async.series(tasks, function(error) {
+      if (error) {
+        fail(error);
+      } else {
+        done();
+      }
+    });
+  });
 };

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -28,7 +28,6 @@ module.exports = function(grunt) {
   }
 
   function clean(dir, callback) {
-    log('grunt-bower ' + 'cleaning '.cyan + dir.grey);
     rimraf(dir);
     callback();
   }

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -75,6 +75,10 @@ module.exports = function(grunt) {
     log.logger = options.verbose && grunt.log;
     options.layout = LayoutsManager.getLayout(options.layout, fail);
 
+    if (options.cleanup) {
+      options.cleanTargetDir = options.cleanBowerDir = true;
+    }
+
     if (options.cleanTargetDir) {
       add(function(callback) {
         clean(targetDir, callback);

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -65,8 +65,10 @@ module.exports = function(grunt) {
       }),
       add = function(name, fn) {
         tasks.push(function(callback) {
-          fn(callback);
-          grunt.log.ok('grunt-bower ' + name.cyan);
+          fn(function() {
+            grunt.log.ok(name);
+            callback();
+          });
         });
       },
       bowerDir = path.resolve(bower.config.directory),
@@ -80,23 +82,23 @@ module.exports = function(grunt) {
     }
 
     if (options.cleanTargetDir) {
-      add('clean-target-dir', function(callback) {
+      add('Cleaned target dir ' + targetDir.grey, function(callback) {
         clean(targetDir, callback);
       });
     }
 
     if (options.install) {
-      add('install', install);
+      add('Installed bower packages', install);
     }
 
     if (options.copy) {
-      add('copy', function(callback) {
+      add('Copied packages to ' + targetDir.grey, function(callback) {
         copy(options, callback);
       });
     }
 
     if (options.cleanBowerDir) {
-      add('clean-bower-dir', function(callback) {
+      add('Cleaned bower dir ' + bowerDir.grey, function(callback) {
         clean(bowerDir, callback);
       });
     }

--- a/tasks/lib/layouts_manager.js
+++ b/tasks/lib/layouts_manager.js
@@ -26,22 +26,23 @@ module.exports = {
    * Resolves named layouts, returns functions as is
    *
    * @param {string | Function} layout name or layout function
+   * @param { Function } fail handler
    * @returns {Function} layout function
    */
-  getLayout: function(layout) {
+  getLayout: function(layout, fail) {
     if (_.isFunction(layout)) {
       return layout;
     }
 
     if (!_.isString(layout)) {
-      throw 'Layout should be specified by name or as a function';
+      fail('Layout should be specified by name or as a function');
     }
 
     if (_(defaultLayouts).has(layout)) {
       return defaultLayouts[layout];
     }
 
-    throw 'The following named layouts are supported: ' + _.keys(defaultLayouts).join(', ');
+    fail('The following named layouts are supported: ' + _.keys(defaultLayouts).join(', '));
   }
 
 };


### PR DESCRIPTION
Proposal to split tasks to allow more flexible configuration:
- clean target dir
- bower install
- copy from bower dir to target dir using layout strategy
- clean bower dir

No tests and documentation yet, just a proposal. Fixing #18 and #15 by splitting install and copy task.
