### PR TITLE
Add explicit declaration of async dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",
-    "colors": "~0.6.0-1"
+    "colors": "~0.6.0-1",
+    "async": "~0.1.22"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "0.3.0",


### PR DESCRIPTION
Explicitly declare async module (even though it's a part of grunt) as dependency to fix:

```
Loading "bower_task.js" tasks...ERROR
>> Error: Cannot find module 'async'
Warning: Task "bower:install" not found. Use --force to continue.
```
