### PR TITLE
Update bower v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~0.9.2",
+    "bower": "~0.10.0",
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",

--- a/test/bower_assets_test.js
+++ b/test/bower_assets_test.js
@@ -203,5 +203,30 @@ exports.bower_assets = {
         path.normalize("bo_co/underscore/underscore.css")
       ],
     });
+  },
+  
+  support_bower_components_folder: function(test) {
+    test.expect(1);
+
+    var expected = {
+      "__untyped__": {
+        "jquery": [path.normalize("bower_components/jquery/jquery.js")]
+      }
+    };
+
+    var bower = require("bower");
+    console.log(bower.config.directory);
+    this.bower.config.directory = bower.config.directory;
+    this.bower.config.json = bower.config.json;
+    verify(
+      'support_bower_components_folder',
+      'should match "bower_components"',
+      expected,
+      test,
+      this.bower);
+
+    this.bowerCommands.list.emit('data', {
+      "jquery": path.normalize("bower_components/jquery/jquery.js"),
+    });
   }
 };

--- a/test/fixtures/support_bower_components_folder/bower.json
+++ b/test/fixtures/support_bower_components_folder/bower.json
@@ -1,0 +1,7 @@
+{
+    "name": "support_bower_components_folder",
+    "version": "0.0.0",
+    "dependencies": {
+        "jquery": "2.0.0"
+    }
+}


### PR DESCRIPTION
My team needs to use newer bower.
the latest bower installed all dependencies to `bower_components`.
grunt-bower-task does not work well on `bower_components`.

of course, i know a workaround to use bowerrc, but i would like to use this task without workarounds.
