### PR TITLE
Support bower 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,19 @@
 {
   "name": "grunt-bower-task",
   "description": "Install Bower packages.",
-  "version": "0.2.3",
-  "homepage": "https://github.com/yatskevich/grunt-bower-task",
-  "author": {
-    "name": "Ivan Yatskevich",
-    "email": "ivan@yatskevich.com"
-  },
-  "contributors": [
-    {
-      "name": "Maksim Horbachevsky",
-      "url": "https://github.com/fantactuka"
-    }
-  ],
+  "version": "0.2.4",
+  "homepage": "https://github.com/xzyfer/grunt-bower-task",
   "repository": {
     "type": "git",
-    "url": "git://github.com/yatskevich/grunt-bower-task.git"
+    "url": "git://github.com/xzyfer/grunt-bower-task.git"
   },
   "bugs": {
-    "url": "https://github.com/yatskevich/grunt-bower-task/issues"
+    "url": "https://github.com/xzyfer/grunt-bower-task/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/yatskevich/grunt-bower-task/blob/master/LICENSE-MIT"
+      "url": "https://github.com/xzyfer/grunt-bower-task/blob/master/LICENSE-MIT"
     }
   ],
   "main": "Gruntfile.js",
@@ -34,7 +24,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~0.10.0",
+    "bower": "~1.0.0",
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~1.0.0",
+    "bower": "~1.1.0",
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -34,14 +34,14 @@ module.exports = function(grunt) {
 
   function install(callback) {
     bower.commands.install()
-      .on('data', log)
+      .on('log', log)
       .on('error', fail)
       .on('end', callback);
   }
 
   function copy(options, callback) {
     var bowerAssets = new BowerAssets(bower, options.cwd);
-    bowerAssets.once('data', function(assets) {
+    bowerAssets.once('end', function(assets) {
       var copier = new AssetCopier(assets, options, function(source, destination, isFile) {
         log('grunt-bower ' + 'copying '.cyan + ((isFile ? '' : ' dir ') + source + ' -> ' + destination).grey);
       });

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
 
   function copy(options, callback) {
     var bowerAssets = new BowerAssets(bower, options.cwd);
-    bowerAssets.once('end', function(assets) {
+    bowerAssets.on('end', function(assets) {
       var copier = new AssetCopier(assets, options, function(source, destination, isFile) {
         log('grunt-bower ' + 'copying '.cyan + ((isFile ? '' : ' dir ') + source + ' -> ' + destination).grey);
       });

--- a/tasks/lib/bower_assets.js
+++ b/tasks/lib/bower_assets.js
@@ -6,7 +6,7 @@ var grunt = require('grunt');
 var BowerAssets = function(bower, cwd) {
   this.bower = bower;
   this.cwd = cwd;
-  this.config = bower.config.json;
+  this.config = bower.config.json || 'bower.json';
 };
 
 BowerAssets.prototype = Object.create(Emitter.prototype);
@@ -18,8 +18,8 @@ BowerAssets.prototype.get = function() {
   var exportsOverride = bowerConfig.exportsOverride;
 
   var paths = bower.commands.list({paths: true});
-  paths.on('data', function(data) {
-    this.emit('data', this.mergePaths(data, exportsOverride ? exportsOverride : {}));
+  paths.on('end', function(data) {
+    this.emit('end', this.mergePaths(data, exportsOverride ? exportsOverride : {}));
   }.bind(this));
   paths.on('error', function(err) {
     this.emit('error', err);
@@ -58,7 +58,7 @@ BowerAssets.prototype.mergePaths = function(allPaths, overrides) {
     }
     bowerAssets['__untyped__'][pkg] = pkgPaths;
   };
-  
+
   _(allPaths).each(function(pkgPaths, pkg) {
     // overrides undefined.
     if (_(copyOverrides).isEmpty()) {

--- a/test/bower_assets_test.js
+++ b/test/bower_assets_test.js
@@ -35,7 +35,7 @@ function verify(name, message, expected, test, bower) {
 
   var bowerAssets = setupBowerConfig(name);
   bowerAssets.get()
-    .on('data', function(actual) {
+    .on('end', function(actual) {
       test.deepEqual(actual, expected, message);
       test.done();
     })
@@ -89,7 +89,7 @@ exports.bower_assets = {
       test,
       this.bower);
 
-    this.bowerCommands.list.emit('data', {"jquery": path.normalize("components/jquery/jquery.js")});
+    this.bowerCommands.list.emit('end', {"jquery": path.normalize("components/jquery/jquery.js")});
   },
 
   extendedComponentJson: function(test) {
@@ -117,7 +117,7 @@ exports.bower_assets = {
       test,
       this.bower);
 
-    this.bowerCommands.list.emit('data', {
+    this.bowerCommands.list.emit('end', {
       "bootstrap-sass": [
         path.normalize("components/bootstrap-sass/docs/assets/js/bootstrap.js"),
         path.normalize("components/bootstrap-sass/docs/assets/css/bootstrap.css")
@@ -152,7 +152,7 @@ exports.bower_assets = {
       test,
       this.bower);
 
-    this.bowerCommands.list.emit('data', {
+    this.bowerCommands.list.emit('end', {
       "bootstrap": [
         path.normalize("bo_co/bootstrap/docs/assets/js/bootstrap.js"),
         path.normalize("bo_co/bootstrap/docs/assets/css/bootstrap.css")
@@ -179,7 +179,7 @@ exports.bower_assets = {
         "bootstrap": [ path.normalize("bo_co/bootstrap/lib/_mixins.scss") ]
       },
       "css": {
-        "underscore": [ path.normalize("bo_co/underscore/underscore.css") ] 
+        "underscore": [ path.normalize("bo_co/underscore/underscore.css") ]
       }
     };
 
@@ -192,7 +192,7 @@ exports.bower_assets = {
       test,
       this.bower);
 
-    this.bowerCommands.list.emit('data', {
+    this.bowerCommands.list.emit('end', {
       "bootstrap": [
         path.normalize("bo_co/bootstrap/docs/assets/js/bootstrap.js"),
         path.normalize("bo_co/bootstrap/docs/assets/css/bootstrap.css")
@@ -204,7 +204,7 @@ exports.bower_assets = {
       ],
     });
   },
-  
+
   support_bower_components_folder: function(test) {
     test.expect(1);
 
@@ -225,7 +225,7 @@ exports.bower_assets = {
       test,
       this.bower);
 
-    this.bowerCommands.list.emit('data', {
+    this.bowerCommands.list.emit('end', {
       "jquery": path.normalize("bower_components/jquery/jquery.js"),
     });
   }


### PR DESCRIPTION
Make grunt-bower-task compatible with Bower 1.0.0 and 1.1.0.
Bower changed a bit their API, so grunt-bower-task wasn't working anymore.
