### PR TITLE
Add 'production' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ Default value: `false`
 
 The task will provide more (debug) output when this option is set to `true`. You can also use `--verbose` when running task for same effect.
 
+#### options.production
+Type: `boolean`
+Default value: `false`
+
+Will not fetch bower dev dependencies if set to `true`.
+
 ### Usage Examples
 
 #### Default Options
@@ -151,7 +157,8 @@ grunt.initConfig({
         install: true,
         verbose: false,
         cleanTargetDir: false,
-        cleanBowerDir: false
+        cleanBowerDir: false,
+        production: false
       }
     }
   }

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -32,8 +32,8 @@ module.exports = function(grunt) {
     callback();
   }
 
-  function install(callback) {
-    bower.commands.install()
+  function install(callback, options) {
+    bower.commands.install(null, options)
       .on('log', log)
       .on('error', fail)
       .on('end', callback);
@@ -61,7 +61,8 @@ module.exports = function(grunt) {
         layout: 'byType',
         install: true,
         verbose: false,
-        copy: true
+        copy: true,
+        production: false
       }),
       add = function(name, fn) {
         tasks.push(function(callback) {
@@ -89,7 +90,9 @@ module.exports = function(grunt) {
     }
 
     if (options.install) {
-      add('Installed bower packages', install);
+      add('Installed bower packages', function(callback) {
+        install(callback, {production: options.production});
+      });
     }
 
     if (options.copy) {


### PR DESCRIPTION
Hello,

I ran into issue where I do not want to install project devDependencies (usefull for build or release script). 
I created a new "production" option named according to the `bower install` command one.
So now you can install bower's packages without the dev dependencies

For example

``` js
grunt.initConfig({
  bower: {
    install: {
      options: {
        copy: false
      }
    },
    install_prod: {
      options: {
        copy: false,
        production: true
      }
    }
  }
});
```
