### PR TITLE
need to fail the task if copying fails, it was just silently exiting

### DIFF
--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -46,6 +46,7 @@ module.exports = function(grunt) {
         log('grunt-bower ' + 'copying '.cyan + ((isFile ? '' : ' dir ') + source + ' -> ' + destination).grey);
       });
 
+      copier.once('error', fail);
       copier.once('copied', callback);
       copier.copy();
     }).get();


### PR DESCRIPTION
Copying fails with current version of bower, see https://github.com/bower/bower/pull/784

Bower list --paths reported the main files as a comma separated string, not an array. And grunt-bower-task tries to copy an unsplit string. The issue is fixed in bower (not released yet though), but anyway grunt-bower-task should fail. See this travis CI output for how it currently behaves. It does not fail when copying fails. https://travis-ci.org/mokkabonna/knockout.bindingHandlers.trimmedValue/builds/10326378
