### PR TITLE
makes option "base" usable

### DIFF
--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -72,9 +72,10 @@ module.exports = function(grunt) {
             callback();
           });
         });
-      },
-      bowerDir = path.resolve(bower.config.directory),
-      targetDir = path.resolve(options.targetDir);
+      };
+    options.cwd = bower.config.cwd = path.resolve(options.base || options.cwd || process.cwd());
+    var bowerDir = path.resolve(options.cwd + '/' + bower.config.directory),
+      targetDir = options.targetDir = path.resolve(options.cwd + '/' + options.targetDir);
 
     log.logger = options.verbose ? grunt.log : grunt.verbose;
     options.layout = LayoutsManager.getLayout(options.layout, fail);


### PR DESCRIPTION
The scenario is, that i have several bower.json files in a project.
with the following changes, the user can set the "base" or "cwd" option to tell the task, where the bower.json can be found.

It is also useful in the case, where the bower.json is not in the same directory as the Gruntfile.js
