### PR TITLE
Restore original logging

### DIFF
--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
   function install(callback) {
     bower.commands.install()
       .on('log', function(result) {
-        log(result.id + ' ' + result.message);
+        log(['bower', result.id.cyan, result.message].join(' '));
       })
       .on('error', fail)
       .on('end', callback);


### PR DESCRIPTION
This restores logging to how it used to be prior to the bower 1.1.x update in https://github.com/yatskevich/grunt-bower-task/commit/91ab688b9a444322dfe0f19241a064b7146d95a3
