### PR TITLE
Update to bower 1.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~1.1.0",
+    "bower": "~1.2.0",
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",


### PR DESCRIPTION
Related to #62.

It does make the error go away. Bower now always returns an array. However #62 should still included  to make sure grunt-bower-task does not fail silently if something similar or other copy issues occur.
