### PR TITLE
fix wrong package files which return from bower.comands.list

### DIFF
--- a/tasks/lib/bower_assets.js
+++ b/tasks/lib/bower_assets.js
@@ -24,7 +24,7 @@ Assets.prototype.addOverridden = function(override, pkg) {
 
 Assets.prototype.addUntyped = function(pkgFiles, pkg) {
   if (!_.isArray(pkgFiles)) {
-    pkgFiles = [ pkgFiles ];
+    pkgFiles = pkgFiles.split(',');
   }
   this._assets['__untyped__'][pkg] = pkgFiles;
 };


### PR DESCRIPTION
graunt-bower-task install will failed because bower.comands.list return a string with comma instead of Array 

jekyll 1.1.2
bower 1.2.6
grunt-bower-task 0.3.1
