### PR TITLE
Add config options that's passed to bower.install

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,19 @@ Default value: `false`
 
 The task will provide more (debug) output when this option is set to `true`. You can also use `--verbose` when running task for same effect.
 
+#### options.bowerOptions
+Type: `Object`
+Default value: `{}`
+
+An options object passed through to the `bower.install` api, possible options are as follows:
+
+```
+{
+    forceLatest: true|false,    // Force latest version on conflict
+    production: true|false,     // Do not install project devDependencies
+}
+```
+
 ### Usage Examples
 
 #### Default Options
@@ -151,7 +164,8 @@ grunt.initConfig({
         install: true,
         verbose: false,
         cleanTargetDir: false,
-        cleanBowerDir: false
+        cleanBowerDir: false,
+        bowerOptions: {}
       }
     }
   }

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -32,8 +32,8 @@ module.exports = function(grunt) {
     callback();
   }
 
-  function install(callback) {
-    bower.commands.install()
+  function install(options, callback) {
+    bower.commands.install([], options.bowerOptions)
       .on('log', function(result) {
         log(['bower', result.id.cyan, result.message].join(' '));
       })
@@ -63,7 +63,8 @@ module.exports = function(grunt) {
         layout: 'byType',
         install: true,
         verbose: false,
-        copy: true
+        copy: true,
+        bowerOptions: {}
       }),
       add = function(successMessage, fn) {
         tasks.push(function(callback) {
@@ -91,7 +92,9 @@ module.exports = function(grunt) {
     }
 
     if (options.install) {
-      add('Installed bower packages', install);
+      add('Installed bower packages', function(callback) {
+        install(options, callback);
+      });
     }
 
     if (options.copy) {


### PR DESCRIPTION
This pull request as a `bowerOptions` config object that is passed through to `bower.install`. This is a more generic implementation of https://github.com/yatskevich/grunt-bower-task/pull/59 which also closes https://github.com/yatskevich/grunt-bower-task/pull/82.
