### PR TITLE
Added option to force the targetDir to be the bower dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Default value: `./lib`
 
 A directory where you want to keep your Bower packages.
 
+#### options.overrideBowerDirectory
+Type: `Boolean`
+Default value: `false`
+
+Override the bower directory configuration with the `targetDir`
+
 #### options.install
 Type: `Boolean`
 Default value: `true`

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
         cleanTargetDir: false,
         cleanBowerDir: false,
         targetDir: './lib',
-		overrideBowerDirectory : false,
+				overrideBowerDirectory : false,
         layout: 'byType',
         install: true,
         verbose: false,
@@ -74,14 +74,14 @@ module.exports = function(grunt) {
           });
         });
       };
-	  
-	if(options.overrideBoweDirectory){
-		bower.config.directory = options.targetDir;
-	}
+    
+    if(options.overrideBoweDirectory){
+      bower.config.directory = options.targetDir;
+    }
 	
     options.cwd = bower.config.cwd = path.resolve(options.base || options.cwd || process.cwd());
-    var bowerDir = path.resolve(options.cwd + '/' + bower.config.directory),
-      targetDir = options.targetDir = path.resolve(options.cwd + '/' + options.targetDir);
+    var bowerDir = path.resolve(options.cwd + '/' + bower.config.directory);
+    var targetDir = options.targetDir = path.resolve(options.cwd + '/' + options.targetDir);
 
     log.logger = options.verbose ? grunt.log : grunt.verbose;
     options.layout = LayoutsManager.getLayout(options.layout, fail);

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -74,6 +74,7 @@ module.exports = function(grunt) {
         });
       };
     options.cwd = bower.config.cwd = path.resolve(options.base || options.cwd || process.cwd());
+	bower.config.directory = options.targetDir;
     var bowerDir = path.resolve(options.cwd + '/' + bower.config.directory),
       targetDir = options.targetDir = path.resolve(options.cwd + '/' + options.targetDir);
 

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -75,7 +75,7 @@ module.exports = function(grunt) {
         });
       };
     
-    if(options.overrideBoweDirectory){
+    if(options.overrideBowerDirectory){
       bower.config.directory = options.targetDir;
     }
 	

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -60,6 +60,7 @@ module.exports = function(grunt) {
         cleanTargetDir: false,
         cleanBowerDir: false,
         targetDir: './lib',
+		overrideBowerDirectory : false,
         layout: 'byType',
         install: true,
         verbose: false,
@@ -73,8 +74,12 @@ module.exports = function(grunt) {
           });
         });
       };
+	  
+	if(options.overrideBoweDirectory){
+		bower.config.directory = options.targetDir;
+	}
+	
     options.cwd = bower.config.cwd = path.resolve(options.base || options.cwd || process.cwd());
-	bower.config.directory = options.targetDir;
     var bowerDir = path.resolve(options.cwd + '/' + bower.config.directory),
       targetDir = options.targetDir = path.resolve(options.cwd + '/' + options.targetDir);
 

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -72,9 +72,10 @@ module.exports = function(grunt) {
             callback();
           });
         });
-      },
-      bowerDir = path.resolve(bower.config.directory),
-      targetDir = path.resolve(options.targetDir);
+      };
+    options.cwd = bower.config.cwd = path.resolve(options.base || options.cwd || process.cwd());
+    var bowerDir = path.resolve(options.cwd + '/' + bower.config.directory),
+      targetDir = options.targetDir = path.resolve(options.cwd + '/' + options.targetDir);
 
     log.logger = options.verbose ? grunt.log : grunt.verbose;
     options.layout = LayoutsManager.getLayout(options.layout, fail);


### PR DESCRIPTION
I was getting frustrated managing the targetDir and bower directory ( through bower config ). So I added this option to force the bower directory to be overriden with the targetDir option.
