### PR TITLE
delay loading dependencies until task execution

### DIFF
--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -10,7 +10,17 @@
 
 module.exports = function(grunt) {
 
-  var bower = require('bower'),
+  var bower,
+    path,
+    async,
+    colors,
+    rimraf,
+    BowerAssets,
+    AssetCopier,
+    LayoutsManager;
+
+  function requireDependencies () {
+    bower = require('bower'),
     path = require('path'),
     async = require('async'),
     colors = require('colors'),
@@ -18,6 +28,7 @@ module.exports = function(grunt) {
     BowerAssets = require('./lib/bower_assets'),
     AssetCopier = require('./lib/asset_copier'),
     LayoutsManager = require('./lib/layouts_manager');
+  }
 
   function log(message) {
     log.logger.writeln(message);
@@ -73,8 +84,16 @@ module.exports = function(grunt) {
           });
         });
       },
-      bowerDir = path.resolve(bower.config.directory),
-      targetDir = path.resolve(options.targetDir);
+      bowerDir,
+      targetDir;
+
+    // calling require on the dependencies has been delayed to prevent slow
+    // dependencies delaying the startup of grunt even if this task is not used
+    // at all
+    requireDependencies();
+
+    bowerDir = path.resolve(bower.config.directory);
+    targetDir = path.resolve(options.targetDir);
 
     log.logger = options.verbose ? grunt.log : grunt.verbose;
     options.layout = LayoutsManager.getLayout(options.layout, fail);


### PR DESCRIPTION
bower is extremely slow to require(), therefore just loading the bower task
will masssively slow down a grunt build even if the bower task is not executed
in that particular grunt run

Actually, I realize this is a somewhat crude hack and the issue should be properly fixed in bower (by not wasting a whole second for a require on decent hardware) and maybe also in the grunt API (something like an `initialize` method that is only run when the task is actually used) - but this annoyed me so much so many times every single day that I had a quick shot at it... Feel free to close and hate me for this PR. Or if you have a better idea for a cleaner workaround, I'd love to hear it ;)

:sparkling_heart:, Chris
