### PR TITLE
allow "common CLI options" with bower.install via config object (allows offline mode, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ An options object passed through to the `bower.install` api, possible options ar
 }
 ```
 
+#### options.bowerConfig
+Type: `Object`
+Default value: `{}`
+
+Additional CLI options that are typically avaibable to all bower commands (not just install). The object is passed through to the `bower.install` api. Possible options are as follows:
+
+```
+{
+    offline: true|false,    // allow install from cache without online validation check
+}
+```
+
 ### Usage Examples
 
 #### Default Options
@@ -170,18 +182,6 @@ grunt.initConfig({
     }
   }
 });
-```
-
-#### options.bowerConfig
-Type: `Object`
-Default value: `{}`
-
-A config object passed through to the `bower.install` api, possible options are as follows:
-
-```
-{
-    offline: true|false,    // allow install from cache without online validation check
-}
 ```
 
 #### Custom Options

--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ grunt.initConfig({
 });
 ```
 
+#### options.bowerConfig
+Type: `Object`
+Default value: `{}`
+
+A config object passed through to the `bower.install` api, possible options are as follows:
+
+```
+{
+    offline: true|false,    // allow install from cache without online validation check
+}
+```
+
 #### Custom Options
 In this initial version there are no more options in plugin itself. **BUT!**
 

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
   }
 
   function install(options, callback) {
-    bower.commands.install([], options.bowerOptions)
+    bower.commands.install([], options.bowerOptions, options.bowerConfig)
       .on('log', function(result) {
         log(['bower', result.id.cyan, result.message].join(' '));
       })
@@ -64,7 +64,8 @@ module.exports = function(grunt) {
         install: true,
         verbose: false,
         copy: true,
-        bowerOptions: {}
+        bowerOptions: {},
+        bowerConfig: {}
       }),
       add = function(successMessage, fn) {
         tasks.push(function(callback) {


### PR DESCRIPTION
This allows the user to specify offline mode, or any other supported config options defined by bower:
https://github.com/bower/bower/blob/13d37b9d5f971dd298b246bbc2a4233cc2137dd6/lib/config.js

```
force: { type: Boolean, shorthand: 'f' },
offline: { type: Boolean, shorthand: 'o' },
verbose: { type: Boolean, shorthand: 'V' },
quiet: { type: Boolean, shorthand: 'q' },
loglevel: { type: String, shorthand: 'l' },
json: { type: Boolean, shorthand: 'j' },
silent: { type: Boolean, shorthand: 's' }
```

These differ from the options support added for #83 in that they are available to other bower commands than just "install". I'm not really sure of their usefulness, except for offline mode.
