### PR TITLE
Updating README to add a note to explain a usecase

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Default value: `true`
 
 Copy Bower packages to target directory.
 
+**NOTE:** If set to false then the installed components will be left in the bower_components folder, which is default bower behaviour. Also setting this to false will allow the task to pass through runs where the bower.json file is not present.
+
 #### options.cleanup
 Type: `boolean`
 Default value: `undefined`


### PR DESCRIPTION
I'm currently re-using bower config files for all my grunt "apps" and I had an issue where some of my apps don't use bower and don't have bower.json files. To get this task to continue in those cases without an error i just needed to set **copy** to false. 

I hope i explained the use case in the change, but I mainly wanted to start the ball rolling for this docs update. I am not usually the best at wording these things ;)
