### PR TITLE
increase flexibility in custom layout function

### DIFF
--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -40,7 +40,7 @@ Copier.prototype.copyAssets = function(type, assets) {
       var destination;
 
       var isFile = fs.statSync(source).isFile();
-      var destinationDir = path.join(self.options.targetDir, self.options.layout(type, pkg));
+      var destinationDir = path.join(self.options.targetDir, self.options.layout(type, pkg, source));
       grunt.file.mkdir(destinationDir);
       if (isFile) {
         destination = path.join(destinationDir, path.basename(source));


### PR DESCRIPTION
By passing in the full "source" path of the file.

For my use case, I need to have more flexibility around which directory I move certain files to. Specifically, I expect bower components which (for component named mattc):
- expect single directory with all templates: mattc/templates/*.dust
- expect one or more locale based directory endpoint mattc/locales/{CC}/{lc}/*.properties where CC=country code and lc=language code

grunt-bower-task layout needs to:
- copy mattc/templates/*.dust -> public/templates/components/mattc/*.dust
- copy mattc/locales/{CC}/{lc}/*.properties -> locales/{CC}/{lc}/mattc/*.properties

To achieve this, the layout function almost could do it, but just needed the full component path of the file to complete the journey.  E.g.

``` javascript
layout: function(type, component, src) {
    var loc, newpath;
    if (type === "properties") {
        //what is the {CC}/{lc} ?
        loc = src.match(/[A-Z]{2}\/[a-z]{2}/g);
        newpath = "../locales/" + loc + "/" + component + "/";
    } else if (type === "dust") {
        newpath = "../public/templates/components/" + component + "/";
    }
    return path.join(newpath);
},
```
