### PR TITLE
updated bower dependency to 1.3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~1.2.0",
+    "bower": "~1.3.8",
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",


### PR DESCRIPTION
updated bower dependency to use version 1.3.8, Fixes "Fatal error: Arguments to path.join must be strings" issues when calling "bower:install" task.
