### PR TITLE
[GM] Upping dependency version for bower, to fix bug around path.join

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "bower": "~1.2.0",
+    "bower": "~1.3.8",
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
     "wrench": "~1.4.3",


### PR DESCRIPTION
I'm hitting a bug in the dependent version of Bower, around path.join, that's been fixed in a recent version. I've just upped the version of Bower in package.json here.
