### PR TITLE
Added option to only copy newer files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Default value: `true`
 
 Copy Bower packages to target directory.
 
+#### options.newerOnly
+Type: `Boolean`
+Default value: `false`
+
+Only copy files that are newer.
+
 #### options.cleanup
 Type: `boolean`
 Default value: `undefined`

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -75,6 +75,7 @@ module.exports = function(grunt) {
         install: true,
         verbose: false,
         copy: true,
+        newerOnly: false,
         bowerOptions: {}
       }),
       add = function(successMessage, fn) {

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -39,12 +39,18 @@ Copier.prototype.copyAssets = function(type, assets) {
     _(sources).each(function(source) {
       var destination;
 
-      var isFile = fs.statSync(source).isFile();
+      var sourceStats = fs.statSync(source);
+      var isFile = sourceStats.isFile();
       var destinationDir = path.join(self.options.targetDir, self.options.layout(type, pkg, source));
       grunt.file.mkdir(destinationDir);
       if (isFile) {
         destination = path.join(destinationDir, path.basename(source));
-        grunt.file.copy(source, destination);
+        if (self.options.newerOnly && fs.existsSync(destination) && sourceStats.mtime < fs.statSync(destination).mtime) {
+          return;
+        }
+        else {
+          grunt.file.copy(source, destination);
+        }
       } else {
         destination = destinationDir;
         wrench.copyDirSyncRecursive(source, destination);


### PR DESCRIPTION
This would be useful for people who, like me, use `bower link` to work on some bower packages and use them in an app.

Before this change, all files would be copied and that would defeat plugins like `grunt-newer`.
