### PR TITLE
Force main file for target folders automatically (exportsOverride automatic/generic variant)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
     simplemocha: {
       options: {
         timeout: '2s',
-        reporter: 'nyan'
+        reporter: 'spec'
       },
 
       all: { src: ['specs/**/*.js'] }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,13 @@
     "test": "grunt test"
   },
   "dependencies": {
+    "async": "~0.1.22",
     "bower": "~1.3.0",
+    "colors": "~0.6.0-1",
+    "glob": "~4.0.6",
     "lodash": "~0.10.0",
     "rimraf": "~2.0.2",
-    "wrench": "~1.4.3",
-    "colors": "~0.6.0-1",
-    "async": "~0.1.22"
+    "wrench": "~1.4.3"
   },
   "devDependencies": {
     "grunt": "~0.4.1",

--- a/specs/asset_copier_spec.js
+++ b/specs/asset_copier_spec.js
@@ -1,0 +1,20 @@
+'use strict';
+/* jshint expr: true */
+/* global describe:false, it:false */
+
+var chai = require('chai'),
+    should = chai.should(),
+    Copier = require('../tasks/lib/asset_copier');
+
+describe('Asset Copier:', function(){
+    var AssetCopier = new Copier();
+
+    describe('Method findMainFile', function(){
+        it('should never abort on errors/exceptions', function(){
+            var src = 'sdfs$%$£%$%&%^*$&^*@£$@£$@sdfsd',
+                pkg = 'sdfsdf!@£$%^&*()_+=}{sdfsd';
+
+            (AssetCopier.findMainFile.bind(AssetCopier, src, pkg)).should.not.throw(ReferenceError);
+        });
+    });
+});

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -68,6 +68,7 @@ module.exports = function(grunt) {
     var tasks = [],
       done = this.async(),
       options = this.options({
+        forceMain: false,
         cleanTargetDir: false,
         cleanBowerDir: false,
         targetDir: './lib',

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -69,6 +69,7 @@ module.exports = function(grunt) {
       done = this.async(),
       options = this.options({
         forceMain: false,
+        mainPattern: null,
         cleanTargetDir: false,
         cleanBowerDir: false,
         targetDir: './lib',

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
       done = this.async(),
       options = this.options({
         forceMain: false,
-        mainPattern: null,
+        forceMainPattern: null,
         cleanTargetDir: false,
         cleanBowerDir: false,
         targetDir: './lib',

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -43,7 +43,6 @@ Copier.prototype.copyAssets = function(type, assets) {
       var isFile = fs.statSync(source).isFile();
       var destinationDir = path.join(self.options.targetDir, self.options.layout(type, pkg, source));
 
-      grunt.file.mkdir(destinationDir);
       if (isFile) {
         destination = path.join(destinationDir, path.basename(source));
         grunt.file.copy(source, destination);
@@ -57,6 +56,10 @@ Copier.prototype.copyAssets = function(type, assets) {
         destination = destinationDir;
         wrench.copyDirSyncRecursive(source, destination);
       }
+      if(source !== undefined) {
+          grunt.file.mkdir(destinationDir);
+      }
+
       self.report(source, destination, isFile);
     });
   });

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -87,7 +87,7 @@ Copier.prototype.findMainFile = function (src, pkg) {
                     'pkg': pkg.cyan
                 },
                 msg = 'Unable to copy package <%= pkg %>, because <%= filePattern %> not found. ' +
-                    'Use "exportsOverride" in bower.json instead.';
+                      'Use "exportsOverride" in bower.json instead.';
 
             msg = _.template(msg, tmplData);
 

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -66,17 +66,19 @@ Copier.prototype.findMainFile = function (src, pkg) {
         ext : "js"
     };
 
+    var patternOrig = src + "/**/" + ptrn.main + "." + ptrn.ext;
+
     _.extend(ptrn, this.options.mainPattern);
 
-    var fileNamePtrn = ptrn.main + "." + ptrn.ext,
-        pattern = src + "/**/" + fileNamePtrn,
-        source = glob.sync(pattern, {nocase: true});
+    var fileMatch = ptrn.main + "." + ptrn.ext,
+        patternNew = src + "/**/" + fileMatch,
+        source = glob.sync(patternNew, {nocase: true})[0] || glob.sync(patternOrig, {nocase: true})[0];
 
-    if(source[0] === undefined) {
-        throw new ReferenceError('Unable to find "' + fileNamePtrn + '" in ' + src + ' directory');
+    if(source === undefined) {
+        throw new ReferenceError('Unable to find "' + fileMatch + '" in ' + src + ' directory');
     }
 
-    return source[0];
+    return source;
 };
 
 module.exports = Copier;

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var glob = require("glob");
 var Emitter = require('events').EventEmitter;
 var wrench = require('wrench');
 var path = require('path');
@@ -45,6 +46,10 @@ Copier.prototype.copyAssets = function(type, assets) {
       if (isFile) {
         destination = path.join(destinationDir, path.basename(source));
         grunt.file.copy(source, destination);
+      } else if(self.options.forceMain){
+          source = self.setMainFile(source, pkg);
+          destination = path.join(destinationDir, path.basename(source));
+          grunt.file.copy(source, destination);
       } else {
         destination = destinationDir;
         wrench.copyDirSyncRecursive(source, destination);
@@ -52,6 +57,29 @@ Copier.prototype.copyAssets = function(type, assets) {
       self.report(source, destination, isFile);
     });
   });
+};
+
+Copier.prototype.setMainFile = function (src, pkg) {
+
+    var self = this,
+        pattern = src + "/**/" + pkg.slice(pkg.indexOf("-") + 1) + ".js";
+
+    self.getMainFile(pattern);
+
+    if(self.src !== undefined){
+        src = self.src;
+    }
+
+    return src;
+};
+
+Copier.prototype.getMainFile = function (pattern) {
+    var self = this,
+        source  = glob.sync(pattern, {nocase: true});
+
+    _(source).each(function(item){
+        self.src = item;
+    });
 };
 
 module.exports = Copier;

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -42,16 +42,13 @@ Copier.prototype.copyAssets = function(type, assets) {
 
       var isFile = fs.statSync(source).isFile();
       var destinationDir = path.join(self.options.targetDir, self.options.layout(type, pkg, source));
-      var mainPattern = {
-          main: pkg.slice(pkg.indexOf("-") + 1),
-          ext : "js"
-      };
+
       grunt.file.mkdir(destinationDir);
       if (isFile) {
         destination = path.join(destinationDir, path.basename(source));
         grunt.file.copy(source, destination);
       } else if(self.options.forceMain){
-          source = self.findMainFile(source, pkg, mainPattern);
+          source = self.findMainFile(source, pkg);
           destination = path.join(destinationDir, path.basename(source));
           grunt.file.copy(source, destination);
       } else {
@@ -62,8 +59,12 @@ Copier.prototype.copyAssets = function(type, assets) {
     });
   });
 };
+Copier.prototype.findMainFile = function (src, pkg) {
 
-Copier.prototype.findMainFile = function (src, pkg, ptrn) {
+    var ptrn = {
+        main: pkg.slice(pkg.indexOf("-") + 1),
+        ext : "js"
+    };
 
     _.extend(ptrn, this.options.mainPattern);
 

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -49,8 +49,10 @@ Copier.prototype.copyAssets = function(type, assets) {
         grunt.file.copy(source, destination);
       } else if(self.options.forceMain){
           source = self.findMainFile(source, pkg);
-          destination = path.join(destinationDir, path.basename(source));
-          grunt.file.copy(source, destination);
+          if(source !== undefined){
+              destination = path.join(destinationDir, path.basename(source));
+              grunt.file.copy(source, destination);
+          }
       } else {
         destination = destinationDir;
         wrench.copyDirSyncRecursive(source, destination);

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -7,74 +7,74 @@ var grunt = require('grunt');
 var fs = require('fs');
 
 var Copier = function(assets, options, report) {
-  this.assets = assets;
-  this.options = options;
-  this.report = report;
+    this.assets = assets;
+    this.options = options;
+    this.report = report;
 };
 
 Copier.prototype = Object.create(Emitter.prototype);
 Copier.prototype.constructor = Copier;
 
 Copier.prototype.copy = function() {
-  var error;
-  _(this.assets).each(function(typedAssets, type) {
-    try {
-      this.copyAssets(type, typedAssets);
-    } catch (err) {
-      error = err;
-      this.emit('error', err);
-      return false;
+    var error;
+    _(this.assets).each(function(typedAssets, type) {
+        try {
+            this.copyAssets(type, typedAssets);
+        } catch (err) {
+            error = err;
+            this.emit('error', err);
+            return false;
+        }
+    }, this);
+
+    if (!error) {
+        this.emit('copied');
     }
-  }, this);
 
-  if (!error) {
-    this.emit('copied');
-  }
-
-  return this;
+    return this;
 };
 
 Copier.prototype.copyAssets = function(type, assets) {
-  var self = this;
-  _(assets).each(function(sources, pkg) {
-    _(sources).each(function(source) {
-      var destination;
+    var self = this;
+    _(assets).each(function(sources, pkg) {
+        _(sources).each(function(source) {
+            var destination;
 
-      var isFile = fs.statSync(source).isFile();
-      var destinationDir = path.join(self.options.targetDir, self.options.layout(type, pkg, source));
+            var isFile = fs.statSync(source).isFile();
+            var destinationDir = path.join(self.options.targetDir, self.options.layout(type, pkg, source));
 
-      if (isFile) {
-        destination = path.join(destinationDir, path.basename(source));
-        grunt.file.copy(source, destination);
-      } else if(self.options.forceMain){
-          source = self.findMainFile(source, pkg);
-          if(source !== undefined){
-              destination = path.join(destinationDir, path.basename(source));
-              grunt.file.copy(source, destination);
-          }
-      } else {
-        destination = destinationDir;
-        wrench.copyDirSyncRecursive(source, destination);
-      }
-      if(source !== undefined) {
-          grunt.file.mkdir(destinationDir);
-      }
+            if (isFile) {
+                destination = path.join(destinationDir, path.basename(source));
+                grunt.file.copy(source, destination);
+            } else if(self.options.forceMain){
+                source = self.findMainFile(source, pkg);
+                if(source !== undefined){
+                    destination = path.join(destinationDir, path.basename(source));
+                    grunt.file.copy(source, destination);
+                }
+            } else {
+                destination = destinationDir;
+                wrench.copyDirSyncRecursive(source, destination);
+            }
 
-      self.report(source, destination, isFile);
+            if(source !== undefined) {
+                grunt.file.mkdir(destinationDir);
+            }
+
+            self.report(source, destination, isFile);
+        });
     });
-  });
 };
 
 Copier.prototype.findMainFile = function (src, pkg) {
 
     var ptrn = {
-        main: pkg.slice(pkg.indexOf("-") + 1),
-        ext: "js"
-    };
+            main: pkg.slice(pkg.search(/[\-\_\[\]\/\{\}\(\)\+\?\.\\\^\$\|]/g) + 1),
+            ext: "js"
+        },
+        ptrnOrig = src + "/**/" + ptrn.main + "." + ptrn.ext;
 
-    var ptrnOrig = src + "/**/" + ptrn.main + "." + ptrn.ext;
-
-    _.extend(ptrn, this.options.mainPattern);
+    _.extend(ptrn, this.options ? this.options.forceMainPattern : {});
 
     var filePattern = ptrn.main + "." + ptrn.ext,
         patternNew = src + "/**/" + filePattern,
@@ -86,8 +86,8 @@ Copier.prototype.findMainFile = function (src, pkg) {
                     'filePattern': filePattern.cyan,
                     'pkg': pkg.cyan
                 },
-                msg = 'Unable to copy package <%= pkg %>, because <%= filePattern %> not found. '
-                    + 'Use "exportsOverride" in bower.json instead.';
+                msg = 'Unable to copy package <%= pkg %>, because <%= filePattern %> not found. ' +
+                    'Use "exportsOverride" in bower.json instead.';
 
             msg = _.template(msg, tmplData);
 
@@ -100,6 +100,6 @@ Copier.prototype.findMainFile = function (src, pkg) {
     finally {
         return source;
     }
-}
+};
 
 module.exports = Copier;

--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -86,7 +86,7 @@ Copier.prototype.findMainFile = function (src, pkg) {
                     'filePattern': filePattern.cyan,
                     'pkg': pkg.cyan
                 },
-                msg = 'Unable to install <%= pkg %>, because <%= filePattern %> not found. '
+                msg = 'Unable to copy package <%= pkg %>, because <%= filePattern %> not found. '
                     + 'Use "exportsOverride" in bower.json instead.';
 
             msg = _.template(msg, tmplData);


### PR DESCRIPTION
#### Usage:

in your Gruntfile.js:

``` js
        bower: {
            install: {
                options: {
                    forceMain: true,
                    forceMainPattern: { // this part is optional
                        main: '', // main file name
                        ext: '' // main file extension
                    }
                }
            }
        }
```

Customizable Main file generator for target folders:
Note: this will only apply to those that don't have main key specified in their metadata.
- forceMain: true => triggers the method
- built in regex pattern to look into directories for main file
- custom pattern to look into directories for main file
- fallback to built in if custom not found
- if built in pattern didn't find the main file then don't copy the component
- can use exportsOverride as well as this if main file wasn't found, so to recover the error.
- if not found still continue on the other tasks and never abort the operation, although catches the exception and logs on the console
- test: method should never abort on errors/exceptions
