### PR TITLE
Overridable manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ An options object passed through to the `bower.install` api, possible options ar
 }
 ```
 
+#### options.json
+Type: `String`
+Default value: `bower.json`
+
+Packages manifest file.
+
 ### Usage Examples
 
 #### Default Options
@@ -170,7 +176,8 @@ grunt.initConfig({
         verbose: false,
         cleanTargetDir: false,
         cleanBowerDir: false,
-        bowerOptions: {}
+        bowerOptions: {},
+        json: 'bower.json'
       }
     }
   }

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
   }
 
   function copy(options, callback) {
-    var bowerAssets = new BowerAssets(bower, options.cwd);
+    var bowerAssets = new BowerAssets(bower, options.cwd, options.json);
     bowerAssets.on('end', function(assets) {
       var copier = new AssetCopier(assets, options, function(source, destination, isFile) {
         log('grunt-bower ' + 'copying '.cyan + ((isFile ? '' : ' dir ') + source + ' -> ' + destination).grey);
@@ -75,7 +75,8 @@ module.exports = function(grunt) {
         install: true,
         verbose: false,
         copy: true,
-        bowerOptions: {}
+        bowerOptions: {},
+        json: 'bower.json'
       }),
       add = function(successMessage, fn) {
         tasks.push(function(callback) {

--- a/tasks/lib/bower_assets.js
+++ b/tasks/lib/bower_assets.js
@@ -42,10 +42,10 @@ Assets.prototype.toObject = function() {
 };
 
 
-var BowerAssets = function(bower, cwd) {
+var BowerAssets = function(bower, cwd, json) {
   this.bower = bower;
   this.cwd = cwd;
-  this.config = bower.config.json || 'bower.json';
+  this.config = bower.config.json || json;
   this.assets = new Assets(cwd, bower.config.directory);
 };
 


### PR DESCRIPTION
Give the option to use another file than bower.json. This gives the option to use different bower.json files (and packages) for different tasks.

This fixes #129.
