### PR TITLE
Set copy to default to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Will remove bower's dir after copying all needed files into target dir.
 
 #### options.copy
 Type: `Boolean`
-Default value: `true`
+Default value: `false`
 
 Copy Bower packages to target directory.
 

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -74,7 +74,7 @@ module.exports = function(grunt) {
         layout: 'byType',
         install: true,
         verbose: false,
-        copy: true,
+        copy: false,
         bowerOptions: {}
       }),
       add = function(successMessage, fn) {


### PR DESCRIPTION
The `bower:install` should behave like `bower install` out of the box. So copying files to an alternate location after installing should need to be explicitly turned on.

This would fix #143
