### PR TITLE
Added option to only copy the packages that are declared in bower.json:depedencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Default value: `true`
 
 Copy Bower packages to target directory.
 
+#### options.onlyDepedencies
+Type: `Boolean`
+Default value: `false`
+
+If copy is set to `true` then only copies the packages that are declared in bower.json:depedencies.
+
 #### options.cleanup
 Type: `boolean`
 Default value: `undefined`

--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -53,7 +53,7 @@ module.exports = function(grunt) {
   }
 
   function copy(options, callback) {
-    var bowerAssets = new BowerAssets(bower, options.cwd);
+    var bowerAssets = new BowerAssets(bower, options.cwd, options.onlyDependencies);
     bowerAssets.on('end', function(assets) {
       var copier = new AssetCopier(assets, options, function(source, destination, isFile) {
         log('grunt-bower ' + 'copying '.cyan + ((isFile ? '' : ' dir ') + source + ' -> ' + destination).grey);
@@ -75,6 +75,7 @@ module.exports = function(grunt) {
         install: true,
         verbose: false,
         copy: true,
+        onlyDepedencies: false,
         bowerOptions: {}
       }),
       add = function(successMessage, fn) {

--- a/tasks/lib/bower_assets.js
+++ b/tasks/lib/bower_assets.js
@@ -96,7 +96,7 @@ BowerAssets.prototype.mergePaths = function(bowerComponents, overrides, bowerDep
   };
 
   _(bowerComponents).each(function(pkgFiles, pkg) {
-    var existsDepedency = this.onlyDependencies ? findDependency(pkg) != undefined : true;
+    var existsDepedency = this.onlyDependencies ? findDependency(pkg) !== undefined : true;
 
     if (existsDepedency) {
       var activeOverride = findOverride(pkg);

--- a/tasks/lib/bower_assets.js
+++ b/tasks/lib/bower_assets.js
@@ -42,9 +42,10 @@ Assets.prototype.toObject = function() {
 };
 
 
-var BowerAssets = function(bower, cwd) {
+var BowerAssets = function(bower, cwd, onlyDepedencies) {
   this.bower = bower;
   this.cwd = cwd;
+  this.onlyDependencies = onlyDepedencies;
   this.config = bower.config.json || 'bower.json';
   this.assets = new Assets(cwd, bower.config.directory);
 };
@@ -56,10 +57,15 @@ BowerAssets.prototype.get = function() {
   var bower = this.bower;
   var bowerConfig = grunt.file.readJSON(path.join(this.cwd, this.config));
   var exportsOverride = bowerConfig.exportsOverride;
+  var bowerDependencies = this.onlyDependencies ? bowerConfig.dependencies : {};
 
   var paths = bower.commands.list({paths: true});
   paths.on('end', function(data) {
-    this.emit('end', this.mergePaths(data, exportsOverride ? exportsOverride : {}));
+    this.emit('end', this.mergePaths(
+      data,
+      exportsOverride ? exportsOverride : {},
+      bowerDependencies
+    ));
   }.bind(this));
   paths.on('error', function(err) {
     this.emit('error', err);
@@ -71,24 +77,35 @@ BowerAssets.prototype.get = function() {
 /**
  *
  * @param bowerComponents - output of 'bower list' command
- * @param overrides - overrides coming from 'bower.json'
+ * @param overrides - overrides coming from 'bower.json : exportsOverride'
+ * @param bowerDependencies - if true only installs packages that are in bower 'depedencies' object
  *
  * @returns assets grouped by component and type
  */
-BowerAssets.prototype.mergePaths = function(bowerComponents, overrides) {
+BowerAssets.prototype.mergePaths = function(bowerComponents, overrides, bowerDependencies) {
   var findOverride = function(pkg) {
     return _(overrides).find(function(override, override_key) {
       return packageMatcher.matches(pkg, override_key);
     });
   };
 
-  _(bowerComponents).each(function(pkgFiles, pkg) {
-    var activeOverride = findOverride(pkg);
+  var findDependency = function (pkg) {
+    return _(bowerDependencies).find(function (dependency, dependency_key) {
+        return packageMatcher.matches(pkg, dependency_key);
+    });
+  };
 
-    if (activeOverride) {
-      this.assets.addOverridden(activeOverride, pkg);
-    } else {
-      this.assets.addUntyped(pkgFiles, pkg);
+  _(bowerComponents).each(function(pkgFiles, pkg) {
+    var existsDepedency = this.onlyDependencies ? findDependency(pkg) != undefined : true;
+
+    if (existsDepedency) {
+      var activeOverride = findOverride(pkg);
+
+      if (activeOverride) {
+        this.assets.addOverridden(activeOverride, pkg);
+      } else {
+        this.assets.addUntyped(pkgFiles, pkg);
+      }
     }
   }, this);
 


### PR DESCRIPTION
Hi,

i added a new option "onlyDependencies" so that when "copy" is set to true, it only takes the packages declared in `bower.json:depedencies`.

For example if you want to use only bootstrap css and fonts but not its javascript, in the old version you could declare something like this in **bower.js**:

``` json

  "exportsOverride": {
    "bootstrap": {
      "css": "dist/css/*.*",
      "fonts": "dist/fonts/*.*"
    }
  }
```

but it will copy the jquery depedency because bower installs it in bower_components as it's a declared depedency of bootstrap.

so by adding the **onlyDependencies** property in the task declaration in **gruntfile.js**:

``` javascript

        bower: {
            install: {
                options: {
                    targetDir: "./wwwroot/lib",
                    layout: "byComponent",
                    onlyDependencies: true,
                    bowerOptions: {
                        production: true
                    }
                }
            }
```

it'll only install the css and fonts of bootstrap.
