### PR TITLE
Fixed target directory wipeout even when cleanTargetDir is false

### DIFF
--- a/tasks/lib/asset_copier.js
+++ b/tasks/lib/asset_copier.js
@@ -35,6 +35,8 @@ Copier.prototype.copy = function() {
 
 Copier.prototype.copyAssets = function(type, assets) {
   var self = this;
+  var options = this.options;
+
   _(assets).each(function(sources, pkg) {
     _(sources).each(function(source) {
       var destination;
@@ -47,7 +49,11 @@ Copier.prototype.copyAssets = function(type, assets) {
         grunt.file.copy(source, destination);
       } else {
         destination = destinationDir;
-        wrench.copyDirSyncRecursive(source, destination);
+        var opts = {};
+        if (!options || !options.cleanTargetDir) {
+          opts.preserve = true;
+        }
+        wrench.copyDirSyncRecursive(source, destination, opts);
       }
       self.report(source, destination, isFile);
     });


### PR DESCRIPTION
Hi,
I've just fixed a bad behavior of the Copy action. Basically when the bower package is identified as a folder, the target folder (if already existent) was purged regardless the "cleanTargetDir" property state.
Now it is possible to copy nested packages in any order, the files will be copied in the target dir if already existent.

Thank you!
 Luciano
