### PR TITLE
Making bowerOptions work

### DIFF
--- a/tasks/bower_task.js
+++ b/tasks/bower_task.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
   }
 
   function install(options, callback) {
-    bower.commands.install([], options.bowerOptions)
+    bower.commands.install([], undefined, options.bowerOptions)
       .on('log', function(result) {
         log(['bower', result.id.cyan, result.message].join(' '));
       })


### PR DESCRIPTION
In the newest version of bower, bower options arent considered because the call order of bower.commands.install changed. I corrected this, now it works.
