### PR TITLE
Moved the contribution section out to it's own file

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+## Contributing to grunt-bower-task
+
+First off, thanks for taking the time to make grunt-bower-task even better than it is today! The following is a set of guidelines we'd like you to follow when contributing to the project.
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Your First Code Contribution](#your-first-code-contribution)
+  * [Pull Requests](#pull-requests)
+
+## How Can I Contribute?
+
+### Suggesting Enhancements
+
+This section will guide you through submitting an enhancement suggestion for grunt-bower-task. All enhancement suggestions are tracked as [GitHub issues][issues]. Before creating a new suggestion we ask that you first check to make sure there is not already an [issue requesting that enhancement][enhancements]. We also ask that you look through any issues with the [roadmap][roadmap-label] label to make sure your request isn't already in the works.
+
+### Your First Code Contribution
+
+**Working on your first Pull Request?** You can learn how from this free series [How to Contribute to an Open Source Project on GitHub][egghead-course].
+
+Unsure where to begin contributing to grunt-bower-task? You can start by looking through these `first-timer`, `difficulty:easy` and `help-wanted` issues:
+
+* [First-Timer issues][first-timer] - issues created to help anyone contributing to their first open-source project. (usually contain detailed explanations of the problem and how to fix it)
+* [difficulty:easy issues][difficulty:easy] - issues which should only require a few lines of code, and a test or two.
+* [Help Wanted issues][help-wanted] - issues which should be a bit more involved than `difficulty:easy` issues.
+
+Eash issue lists is sorted by the total number of comments. While not perfect, number of comments is a reasonable proxy for impact a given change will have.
+
+### Pull Requests
+
+* Please, use `devel` branch for all pull requests.
+* In lieu of a formal style guide, take care to maintain the existing coding style.
+* Add unit tests for any new or changed functionality.
+* Lint and test your code using [Grunt][grunt].
+
+[issues]:https://github.com/yatskevich/grunt-bower-task/issues
+[egghead-course]:https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[grunt]:http://gruntjs.com/
+[enhancements]:https://github.com/yatskevich/grunt-bower-task/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement+sort%3Acomments-desc
+[first-timer]:https://github.com/yatskevich/grunt-bower-task/issues?q=is%3Aopen+is%3Aissue+label%3Afirst-timer+sort%3Acomments-desc
+[difficulty:easy]:https://github.com/yatskevich/grunt-bower-task/issues?q=is%3Aopen+is%3Aissue+label%3Adifficulty%3Aeasy+sort%3Acomments-desc
+[help-wanted]:https://github.com/yatskevich/grunt-bower-task/issues?q=is%3Aopen+is%3Aissue+label%3Ahelp-wanted+sort%3Acomments-desc
+[roadmap-label]:https://github.com/yatskevich/grunt-bower-task/issues?q=is%3Aopen+is%3Aissue+label%3Aroadmap

--- a/README.md
+++ b/README.md
@@ -288,11 +288,6 @@ Usage example in `bower.json`:
 - Pay attention to what characters you use in RegExp overrides - '.' and '*' has special meaning in regular expressions.
 - If you put `*` as the first entry in `exportsOverride`, it'll match everything, so other rules will be skipped.
 
-## Contributing
-Please, use `devel` branch for all pull requests.
-
-In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [grunt][].
-
 ## License
 Copyright (c) 2012-2013 Ivan Yatskevich
 


### PR DESCRIPTION
I removed the contributing section from the README and moved it to it's own CONTRUBTING.md. The original contributing section seem a bit small and with the project recently getting attention I thought this would be great time to update this section in order to make newcomers to the project feel more welcome.

@yatskevich feel free to let me if there's anything that you want me to change.

This could probably be followed up by adding an [issue and pull request template](https://github.com/blog/2111-issue-and-pull-request-templates).  If you're alright with that then I'll be happy to create an issue for it and will work on it soon.

**Note:**
Apparently, GitHub recently [added the ability to squash the commits](https://github.com/blog/2141-squash-your-commits) from a PR when you merge them. Can we see about enabling this so that I can squash commits when I merge a PR? This PR would be an excellent way to test to make sure it's working for the both of us. (Yes that blog post is from April 1st and yes I did check into it and supposedly it's not a joke. I've even seen the settings for it just haven't seeing the squash and merge button yet.)
