### PR TITLE
UPDATE: Templates usage in exportsOverride

### DIFF
--- a/tasks/lib/bower_assets.js
+++ b/tasks/lib/bower_assets.js
@@ -86,6 +86,7 @@ BowerAssets.prototype.mergePaths = function(bowerComponents, overrides) {
     var activeOverride = findOverride(pkg);
 
     if (activeOverride) {
+      activeOverride = JSON.parse(_.template(JSON.stringify(activeOverride))({component: pkg}));
       this.assets.addOverridden(activeOverride, pkg);
     } else {
       this.assets.addUntyped(pkgFiles, pkg);


### PR DESCRIPTION
This will allow the use of the template `<%= component %>` in bower.json to make globbing like in grunt tasks.
