### PR TITLE
Fixed documented default value of options.copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Will remove bower's dir after copying all needed files into target dir.
 
 #### options.copy
 Type: `Boolean`
-Default value: `false`
+Default value: `true`
 
 Copy Bower packages to target directory.
 


### PR DESCRIPTION
It would seem the default value for the `copy` option is actually `true`, whereas it states `false` in README.md
