### PR TITLE
fix: pin to 1.4.0 of colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "async": "^2.3.0",
     "bower": "^1.7.9",
     "bower-json": "^0.8.1",
-    "@dabh/colors": "^1.4.0",
+    "colors": "1.4.0",
     "fs-extra": "^2.1.2",
     "lodash": "^4.17.21",
     "rimraf": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "async": "^2.3.0",
     "bower": "^1.7.9",
     "bower-json": "^0.8.1",
-    "colors": "^1.1.2",
+    "@dabh/colors": "^1.4.0",
     "fs-extra": "^2.1.2",
     "lodash": "^4.17.21",
     "rimraf": "^2.6.1"


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR updates the package.json to pin to 1.4.0 of `colors`